### PR TITLE
Comb Proposal

### DIFF
--- a/plugins/LiveCut/LiveCut.cpp
+++ b/plugins/LiveCut/LiveCut.cpp
@@ -447,6 +447,7 @@ protected:
         case LVC_MINDELAY:
             parameter.name = "Comb Min Delay";
             parameter.symbol = "livecut_mindelay";
+            parameter.hints |= kParameterIsLogarithmic;
             parameter.ranges.min = controlLimits[index].first;
             parameter.ranges.max = controlLimits[index].second;
             parameter.ranges.def = LVC_DEFAULTS[index];
@@ -455,6 +456,7 @@ protected:
         case LVC_MAXDELAY:
             parameter.name = "Comb Max Delay";
             parameter.symbol = "livecut_maxdelay";
+            parameter.hints |= kParameterIsLogarithmic;
             parameter.ranges.min = controlLimits[index].first;
             parameter.ranges.max = controlLimits[index].second;
             parameter.ranges.def = LVC_DEFAULTS[index];

--- a/plugins/LiveCut/LiveCutControls.hpp
+++ b/plugins/LiveCut/LiveCutControls.hpp
@@ -99,9 +99,9 @@ static const std::array<std::pair<float, float>, LVC_CONTROL_NR> controlLimits =
     {441.0f, 44100.0f},  // LVC_MAXFREQ
     {0.0f, 1.0f},        // LVC_COMB
     {0.0f, 1.0f},        // LVC_TYPE
-    {0.0f, 0.9f},        // LVC_FEEDBACK
-    {1.0f, 50.0f},       // LVC_MINDELAY
-    {1.0f, 50.0f},       // LVC_MAXDELAY
+    {0.0f, 0.6f},     // LVC_FEEDBACK
+    {0.05f, 10.0f},       // LVC_MINDELAY
+    {0.05f, 10.0f},       // LVC_MAXDELAY
     {1.0f, 16.0f}        // LVC_SEED
 }};
 
@@ -136,7 +136,7 @@ static const float LVC_DEFAULTS[LVC_CONTROL_NR] = {
     0.0f, // LVC_COMB
     0.0f, // LVC_TYPE
     0.5f, // LVC_FEEDBACK
-    10.0f, // LVC_MINDELAY
+    1.0f, // LVC_MINDELAY
     10.0f, //  LVC_MAXDELAY
     1.0f //  LVC_SEED
 };

--- a/plugins/LiveCut/LiveCutUI.cpp
+++ b/plugins/LiveCut/LiveCutUI.cpp
@@ -832,7 +832,7 @@ protected:
             }
             
             // LVC_MINDELAY
-            if (ImGui::SliderFloat("Min Delay", &ui_control[LVC_MINDELAY], controlLimits[LVC_MINDELAY].first, controlLimits[LVC_MINDELAY].second, "%.2f ms", ImGuiSliderFlags_NoInput))
+            if (ImGui::SliderFloat("Min Delay", &ui_control[LVC_MINDELAY], controlLimits[LVC_MINDELAY].first, controlLimits[LVC_MINDELAY].second, "%.2f ms", ImGuiSliderFlags_Logarithmic))
             {
                 if (ImGui::IsItemActivated())
                     editParameter(LVC_MINDELAY, true);
@@ -846,7 +846,7 @@ protected:
             }
             
             // LVC_MAXDELAY
-            if (ImGui::SliderFloat("Max Delay", &ui_control[LVC_MAXDELAY], controlLimits[LVC_MAXDELAY].first, controlLimits[LVC_MAXDELAY].second, "%.2f ms", ImGuiSliderFlags_NoInput))
+            if (ImGui::SliderFloat("Max Delay", &ui_control[LVC_MAXDELAY], controlLimits[LVC_MAXDELAY].first, controlLimits[LVC_MAXDELAY].second, "%.2f ms", ImGuiSliderFlags_Logarithmic))
             {
                 if (ImGui::IsItemActivated())
                     editParameter(LVC_MAXDELAY, true);


### PR DESCRIPTION
Hello! I don't know how you feel about taking PR's for this one, especially ones that change its sound. Lemme know your thoughts on that. 

Here's a proposal though. A lot of cool comb filter sounds live under 1 ms, so it feels a bit sad not to permit that range. :)
Also, at 50ms it seems to almost always make a sorta unmusical-sounding mess. So this proposal changes the total range to 0.05...10ms. And also makes those params logarithmic like the fade param is. 

Sounds great generally, but there always was an issue with the feedback mode (all the way since 2005 as I recall...), that high feedback values will decrease overall volume, except for the occassional hyper loud hard-clipped shriek. This problem of course gets exacerbated at the shorter delay times, so as a temporary fix I've just clamped the param range at 0.6.

It'd be better dynamically change that depending on comb type, and even better to adress the dynamics of the feedback mode. But both of those are beyond me today.  